### PR TITLE
The rpmbuild command was incorrect

### DIFF
--- a/redhat/README.md
+++ b/redhat/README.md
@@ -22,5 +22,5 @@ spectool --sourcedir --get-files zeal.spec
 
 ### Build RPM
 ```sh
-rpmbuild --clean zeal.spec
+rpmbuild -bb zeal.spec
 ```


### PR DESCRIPTION
The --clean option outputs as follows:
```sh
$ rpmbuild --clean zeal.spec 
Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.7hQmPn
+ umask 022
+ cd /home/clarkd/rpmbuild/BUILD
+ rm -rf zeal-0.2.1
+ exit 0
$
```

The -bb option tells rpmbuild to generate binary rpms.