### PR TITLE
redhat: improve packaging

### DIFF
--- a/redhat/zeal.spec
+++ b/redhat/zeal.spec
@@ -1,13 +1,15 @@
 %global _hardened_build 1
+%global debug_package %{nil}
 
 Summary: Zeal: Simple offline API documentation browser
 Name: zeal
 Version: 0.3.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: GPLv3+
 Group: Development/Tools
 URL: https://zealdocs.org/
 Source0: https://github.com/zealdocs/zeal/archive/v%{version}.tar.gz
+BuildRequires: make gcc-c++
 BuildRequires: qt5-qtwebkit-devel libarchive-devel qt5-qtx11extras-devel xcb-util-keysyms-devel
 Requires: qt5-qtbase qt5-qtwebkit libarchive qt5-qtx11extras xcb-util-keysyms
 
@@ -31,6 +33,9 @@ make install
 /usr/share/icons/hicolor/*/apps/zeal.png
 
 %changelog
+* Sun Oct 02 2016 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.3.0-2
+- update build requirements and disable debug package
+
 * Sat Oct 01 2016 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.3.0-1
 - update to v0.3.0
 


### PR DESCRIPTION
- update build requirements to include base requirements gcc-c++ and
  make
- disable debug package as debug files are not produced on builds

For more information on build failures related to debug package see [build#460185](https://copr.fedorainfracloud.org/coprs/abn/zeal/build/460185/).

The build requirement updates were added to be more explicit. In your typical CentOS/Fedora/RHEL build environments you would already have `make` and `gcc-c++` packages.
