### PR TITLE
redhat: support CMake 3 builds for CentOS/RHEL

### DIFF
--- a/redhat/zeal.spec
+++ b/redhat/zeal.spec
@@ -4,12 +4,14 @@
 Summary: Zeal: Simple offline API documentation browser
 Name: zeal
 Version: 0.4.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: GPLv3+
 Group: Development/Tools
 URL: https://zealdocs.org/
 Source0: https://github.com/zealdocs/zeal/archive/v%{version}.tar.gz
-BuildRequires: make gcc-c++ cmake extra-cmake-modules
+%{?fedora:BuildRequires: cmake}
+%{?rhel:BuildRequires: cmake3 cmake3-data}
+BuildRequires: make gcc-c++ extra-cmake-modules
 BuildRequires: qt5-qtwebkit-devel libarchive-devel qt5-qtx11extras-devel
 BuildRequires: xcb-util-keysyms-devel sqlite-devel
 Requires: qt5-qtbase qt5-qtwebkit libarchive qt5-qtx11extras
@@ -22,7 +24,8 @@ Zeal is a simple offline documentation browser inspired by Dash.
 %autosetup
 
 %build
-%cmake .
+%{?fedora:%cmake .}
+%{?rhel:%cmake3 .}
 make %{?_smp_mflags}
 
 %install
@@ -37,6 +40,9 @@ ctest -V %{?_smp_mflags}
 /usr/share/icons/hicolor/*/apps/zeal.png
 
 %changelog
+* Mon Dec 18 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.4.0-3
+- Support CMake 3 builds for CentOS/RHEL distros
+
 * Wed Sep 06 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.4.0-2
 - move to using cmake and checks
 


### PR DESCRIPTION
Adding support for CMake3 builds broke CentOS/RHEL RPM builds. This
allows for conditional switching of build logic to work with the cmake3
packages available in Fedora EPEL repository when building for EL/RHEL
disros.

Note that the built RPM(s) still fail dependency resolution. This is a separate issue that needs to be resolved.