### PR TITLE
redhat: update to v0.6.0

### DIFF
--- a/redhat/zeal.spec
+++ b/redhat/zeal.spec
@@ -1,20 +1,29 @@
 %global _hardened_build 1
-%global debug_package %{nil}
 
-Summary: Zeal: Simple offline API documentation browser
-Name: zeal
-Version: 0.5.0
-Release: 1%{?dist}
-License: GPLv3+
-Group: Development/Tools
-URL: https://zealdocs.org/
-Source0: https://github.com/zealdocs/zeal/archive/v%{version}.tar.gz
-BuildRequires: make gcc-c++
-BuildRequires: desktop-file-utils
-BuildRequires: libarchive-devel
-BuildRequires: qt5-qtbase qt5-qtbase-devel qt5-qtwebkit-devel qt5-qtx11extras-devel
-BuildRequires: xcb-util-keysyms-devel sqlite-devel
-Requires: hicolor-icon-theme
+Name:           zeal
+Version:        0.6.0
+Release:        1%{?dist}
+Summary:        Offline documentation browser inspired by Dash
+
+License:        GPLv3+
+URL:            https://zealdocs.org/
+Source0:        https://github.com/zealdocs/zeal/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+%{?fedora:BuildRequires: cmake}
+%{?rhel:BuildRequires: cmake3}
+%{?rhel:BuildRequires: cmake3-data}
+BuildRequires:  make
+BuildRequires:  extra-cmake-modules
+BuildRequires:  gcc-c++
+BuildRequires:  desktop-file-utils
+BuildRequires:  libarchive-devel
+BuildRequires:  qt5-qtbase
+BuildRequires:  qt5-qtbase-devel
+BuildRequires:  qt5-qtwebkit-devel
+BuildRequires:  qt5-qtx11extras-devel
+BuildRequires:  sqlite-devel
+BuildRequires:  xcb-util-keysyms-devel
+Requires:       hicolor-icon-theme
 
 %description
 Zeal is a simple offline documentation browser inspired by Dash.
@@ -23,12 +32,19 @@ Zeal is a simple offline documentation browser inspired by Dash.
 %autosetup
 
 %build
-%{qmake_qt5} zeal.pro
+# use rpm cmake macro but disable shared libraries and link libs statically
+# as the zeal-libs are not currently expected to be consumed downstream
+%{?fedora:%cmake -DBUILD_SHARED_LIBS:BOOL=OFF .}
+%{?rhel:%cmake3 -DBUILD_SHARED_LIBS:BOOL=OFF .}
 make %{?_smp_mflags}
 
 %install
-%make_install INSTALL_ROOT=%{buildroot}
+%make_install DESTDIR=%{buildroot}
 desktop-file-validate %{buildroot}/%{_datadir}/applications/zeal.desktop
+
+%check
+%{?fedora:ctest}
+%{?rhel:ctest3}
 
 %post
 /bin/touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
@@ -50,6 +66,13 @@ fi
 %{_datadir}/icons/hicolor/*/apps/zeal.png
 
 %changelog
+* Sun Feb 18 2018 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.6.0-1
+- update to v0.6.0
+- update specfile formatting
+- support cmake builds
+- drop qmake build support
+- enable debug package
+
 * Tue Dec 19 2017 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.5.0-1
 - update to v0.5.0
 - align to fedora project maintained rpm specfile (use qmake_qt5 macro)
@@ -68,4 +91,3 @@ fi
 
 * Sat Oct 01 2016 Arun Babu Neelicattu <arun.neelicattu@gmail.com> - 0.3.0-1
 - update to v0.3.0
-


### PR DESCRIPTION
This change also inlcudes multiple formatting changes to align further
to fedora specfile. With this commit, cmake support for build is
completed and qmake is no longer supported. In addition to this, rpm
builds now produce debug packages.