### PR TITLE
Proposal: Automate rpm build and publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+language: python
+
+env:
+  global:
+    - REDHAT_BUILDER_IMAGE=alectolytic/rpmbuilder REDHAT_OS_ARCH=x86_64 COPR_REPOSITORY=@zealdocs/zeal
+  matrix:
+    - PACKAGING=redhat OS_TYPE=fedora OS_DIST=fedora OS_VERSION=27
+    - PACKAGING=redhat OS_TYPE=centos OS_DIST=epel OS_VERSION=7
+
+services:
+  - docker
+
+install: true
+
+script:
+  - |
+    [[ "${PACKAGING}" == "${PACKAGING}" ]] \
+      && git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep redhat/zeal.spec > /dev/null 2>&1 \
+      || { echo "This is not a Red Hat packaging change. Skipping build." && exit 0; }
+    echo "Building Red Hat RPM ..."
+    docker run -v ${PWD}/redhat:/sources -v ${PWD}:/output:Z -e "SRPM_ONLY=1" ${REDHAT_BUILDER_IMAGE}:${OS_TYPE}-${OS_VERSION}
+    pip install copr-cli simplejson jinja2 argparse
+    copr-cli --config .copr build -r ${OS_DIST}-${OS_VERSION}-${REDHAT_OS_ARCH} "${COPR_REPOSITORY}" *.src.rpm


### PR DESCRIPTION
Proposed automation for rpm package builds. Pending changes:
1. Add [.copr.enc](https://gist.github.com/abn/daf262e7e454509df1429c87068923d1#copr-configuration).
2. Add openssl decrypt command in script.
3. Enable travis builds.

@trollixx I was not sure if you intended the automation for publishing builds at [@zealdocs/zeal](https://copr.fedorainfracloud.org/coprs/g/zealdocs/zeal/) to be triggered by changes here or for me to keep maintaining at [abn/zeal-rpm](https://github.com/abn/zeal-rpm). If the latter is the case, feel free to reject this one and I'll go ahead and make the required changes to my repository. If not, I'd recommend that you add or send me a `.copr.enc` file along with the travis openssl command generated, I can fix up the PR to include that before the merge. Once merged the travis build can be enabled.