### PR TITLE
ubuntu-ppa: add jammy/noble support and 0.8.1 changelog entry

### DIFF
--- a/ubuntu-ppa/debian/changelog
+++ b/ubuntu-ppa/debian/changelog
@@ -1,3 +1,7 @@
+zeal (1:0.8.1-1ppa1~#DISTR#1) #DISTR#; urgency=high
+     * New upstream release.
+    -- M.D Saadawy <md.saadawy@gmail.com>  Thu, 21 May 2026 12:45:00 -0400
+
 zeal (1:0.6.1-3ppa1~#DISTR#1) #DISTR#; urgency=low
 
   * New upstream release.

--- a/ubuntu-ppa/ppa-upload.sh
+++ b/ubuntu-ppa/ppa-upload.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Ubuntu distributions
-DISTRS=(bionic cosmic)
+# Added Jammy Noble because it wouldn't work with my noble release 21 May 2026
+DISTRS=(bionic cosmic jammy noble)
 PPA="zeal-developers/ppa"
 
 function failure {

--- a/ubuntu-ppa/ppa-upload.sh
+++ b/ubuntu-ppa/ppa-upload.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Ubuntu distributions
-# Added Jammy Noble because it wouldn't work with my noble release 21 May 2026
-DISTRS=(bionic cosmic jammy noble)
+DISTRS=(jammy noble)
 PPA="zeal-developers/ppa"
 
 function failure {


### PR DESCRIPTION
The DISTRS array in ppa-upload.sh was only targeting bionic and cosmic,
both EOL. This adds jammy (22.04 LTS) and noble (24.04 LTS) to the build
targets, and adds a changelog entry for 0.8.1.

After merging, ppa-upload.sh 0.8.1 will need to be run to upload the
built packages to Launchpad.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog with a new upstream release entry (version 1:0.8.1-1ppa1) and bumped urgency/date metadata.
  * Extended release upload process to include the Ubuntu Noble distribution alongside Jammy, adjusting the per-distribution packaging/upload steps to cover Noble as part of the release pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zealdocs/zeal-packaging/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->